### PR TITLE
Fix deploy of project

### DIFF
--- a/Manager_v2.pro
+++ b/Manager_v2.pro
@@ -27,9 +27,25 @@ QML_IMPORT_PATH =
 QML_DESIGNER_IMPORT_PATH =
 
 # Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /opt/$${TARGET}/bin
-!isEmpty(target.path): INSTALLS += target
+CONFIG(release, debug|release): {
+
+    QT_DIR= $$[QT_HOST_BINS]
+    win32:QMAKE_BIN= \'$$QT_DIR/qmake.exe\'
+    win32:DEPLOYER = %cqtdeployer%
+
+    contains(QMAKE_HOST.os, Linux):{
+        QMAKE_BIN= \'$$QT_DIR/qmake\'
+        DEPLOYER = cqtdeployer
+    }
+
+    DEPLOY_TARGET = $${OUT_PWD}/$${DEBUG_OR_RELEASE}/$$TARGET
+    BASE_DEPLOY_FLAGS = clear -qmake $$QMAKE_BIN -qmlDir \'$$PWD\'  -libDir '\$$PWD'\ -recursiveDepth 4
+    deploy.commands = $$DEPLOYER -bin $$DEPLOY_TARGET $$BASE_DEPLOY_FLAGS
+
+}
+
+QMAKE_EXTRA_TARGETS += \
+    deploy
 
 HEADERS += \
     mymanager.h

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@
   3. Enter terminal inside release folder where Manager_v2 is located
   4. install [CQtDeployer](https://github.com/QuasarApp/CQtDeployer) 
   5. Run next command to generate a Distribution/ folder for generate Distribution in out folder :
-      make deploy
+  
+         make deploy
   6. Run this Distribution/bin/Manager_v2 executable to launch application
 
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@
   1. Build in Qt Creator in 'Release' mode
   2. Clean project
   3. Enter terminal inside release folder where Manager_v2 is located
-  4. Run next command to generate a Distribution/ folder containing bin/Manager_v2 :
-     [x] cqtdeployer -bin Manager_v2 -qmlDir /home/$USER/Qt/5.12.3/gcc_64/qml/ -qmake ~/Qt/5.12.3/gcc_64/bin/qmake clear 
-  5. Run this Distribution/bin/Manager_v2 executable to launch application
+  4. install [CQtDeployer](https://github.com/QuasarApp/CQtDeployer) 
+  5. Run next command to generate a Distribution/ folder for generate Distribution in out folder :
+      make deploy
+  6. Run this Distribution/bin/Manager_v2 executable to launch application
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
hi 
Thank you for using CQtDeployer to deploy your application.
I looked at how you do it and found one mistake.
You used the wrong qmlDir path. This flag should point directly to the qml files you wrote. But you pointed to all available in Qt thereby forced to copy all the necessary and unnecessary qml. You can use the allQmlDependes flag for these purposes.

If you are using qmlDir then it should look like this:
```
-qmlDir ~/Manager_v2
```
But you can’t know in advance where the source folder is located. Therefore, I took the liberty of adding a rule for deployment to your project.

Now you just need to call
```
make deploy
```

### I also updated the assembly instructions.

  1. Build in Qt Creator in 'Release' mode
  2. Clean project
  3. Enter terminal inside release folder where Manager_v2 is located
  4. install [CQtDeployer](https://github.com/QuasarApp/CQtDeployer) 
  5. Run next command to generate a Distribution/ folder for generate Distribution in out folder :
  
         make deploy
  6. Run this Distribution/bin/Manager_v2 executable to launch application
